### PR TITLE
allowing extra options for amqplib

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,8 @@ module.exports.register = function (plugin, userOptions, next) {
     var defaultOptions = {
         url     : "amqp://localhost",
         routing : 'topic',
-        encoding: 'utf8'
+        encoding: 'utf8',
+        extras: {}
     };
 
     var options = Hoek.applyToDefaults(defaultOptions, userOptions);
@@ -57,6 +58,12 @@ module.exports.register = function (plugin, userOptions, next) {
                 };
 
                 pub.connect(exchange, function () {
+                    if(options.hasOwnProperty('extras')) {
+                        for (var key in options.extras) {
+                            pub.setsockopt(key, options.extras[key]);
+                        }
+                    }
+                    
                     pub.publish(exchange + '.' + messageType, JSON.stringify(messageObject));
                     callback(null, messageObject);
                 });


### PR DESCRIPTION
Since this library depends on Rabbit.js  and amqplib i was trying to set some custom options like contentType and i figure there wasn't a way to do it, at least i couldn't find one so i submit a pull request to Rabbit,js to allow `setsockopt` add custom options and here i'm including the option as well for now is only for publish i haven't try with subscription yet.
To make use of this just need to add options to the extras object inside options for example to add contentType should be like this:

in the registration plugin options:

```javascript
module.exports = {
		register: {
			register: require('hapi-rabbit'),
			options: {
				url: process.env.RABBITMQ_URI,
                routing: 'fanout',
                encoding: 'utf8',
                extras: {
					contentType: 'application/json' // extra options here
				}
			}
		},
		callback: HapiRabbitCallback
	};
```