### PR TITLE
Updated example to hapijs 11 of loading plugins

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -23,9 +23,9 @@ npm install hapi-rabbit --save
 ## Examples
 ### load plugin
 ```javascript
-plugin.register([
+server.register([
     {
-        plugin: require('hapi-rabbit'),
+        register: require('hapi-rabbit'),
         options: { 
             url: 'amqp://localhost'
         } 


### PR DESCRIPTION
The way of registering a plugin is outdated in the example. 
